### PR TITLE
Update doConnect by adding extra argument to doAction line 183

### DIFF
--- a/lti/includes/doConnect.php
+++ b/lti/includes/doConnect.php
@@ -180,7 +180,7 @@ function lti_do_connect($tool_provider) {
   // Login the user
   wp_set_current_user($user_id, $user_login);
   wp_set_auth_cookie($user_id);
-  do_action('wp_login', $user_login, $user);  // $ user was added as additional argument for PHP7.2 compatibility MA
+  do_action('wp_login', $user_login, $user);
 
   // Switch to blog
   switch_to_blog($blog_id);

--- a/lti/includes/doConnect.php
+++ b/lti/includes/doConnect.php
@@ -180,7 +180,7 @@ function lti_do_connect($tool_provider) {
   // Login the user
   wp_set_current_user($user_id, $user_login);
   wp_set_auth_cookie($user_id);
-  do_action('wp_login', $user_login);
+  do_action('wp_login', $user_login, $user);  // $ user was added as additional argument for PHP7.2 compatibility MA
 
   // Switch to blog
   switch_to_blog($blog_id);


### PR DESCRIPTION
do_action('wp_login', $user_login, $user); $user was added to prevent PHP7.2 error regarding only 1 argument whereas 2 required...