### PR TITLE
Update WPTool.php

### DIFF
--- a/includes/WPTool.php
+++ b/includes/WPTool.php
@@ -292,8 +292,8 @@ EOD;
 
     protected function init_user($user_login)
     {
-        // Check if this username, $user_login, is already defined
-        $user = get_user_by('login', $user_login);
+        // Check if this username, $user_login, is already defined as username or an existing email
+        $user = get_user_by('login', $user_login) ?: get_user_by('email', $user_login);
 
         if (empty($user)) {
             // Create username if user provisioning is on

--- a/includes/WPTool.php
+++ b/includes/WPTool.php
@@ -248,7 +248,9 @@ EOD;
 
         // Clear any existing connections
         $lti_tool_session['logging_in'] = true;
-        wp_logout();
+        if (is_user_logged_in()) {
+         wp_logout();
+        }
         unset($lti_tool_session['logging_in']);
 
         // Clear these before use


### PR DESCRIPTION
I have made two changes to the WPTool.php file
One fixes an issue I encountered where the wp_logout function would hang and not allow the LTI login to complete. I added an If statement to check if a user is logged in to ensure that if a user is logged in they are logged out before the LTI attempt to login a user.
The secondary is adding email to be search for when attempting to login a user. This helps find pre-existing user if they exist by searching the email.